### PR TITLE
filtering out parks that are lacking values for both latitude and lon…

### DIFF
--- a/scripts/parks/ParkProvider.js
+++ b/scripts/parks/ParkProvider.js
@@ -60,14 +60,18 @@ const rankParks = () => {
 
 const filterParks = () => {
   parks = parks.filter(park => {
-    return park.profileScore >= minimumScore
+    return (
+      park.profileScore >= minimumScore &&
+      park.latitude &&
+      park.longitude
+    )
   })
 }
 
 const filterParkActivities = () => {
   for(const park of parks) {
     park.activities = park.activities.filter(activity => {
-      return desiredActivities.includes(activity.name)
+      return desiredActivities.includes(activity.name) 
     })
   }
 }


### PR DESCRIPTION
1. Verify that `filterParks` in `ParkProvider.js` is now filtering parks based not only on their appeal to Anna, but also is requiring them to have both latitude and longitude properties set to truthy values.
1. Verify that due to this, no park will appear in the dropdown that is missing coordinate values.